### PR TITLE
Update to Remark 6 and Unified Engine 2

### DIFF
--- a/.remarkrc.yaml
+++ b/.remarkrc.yaml
@@ -1,0 +1,3 @@
+presets:
+  - remark-preset-lint-recommended
+  - remark-preset-lint-consistent

--- a/package.json
+++ b/package.json
@@ -28,16 +28,16 @@
   },
   "homepage": "https://github.com/ChristianMurphy/grunt-remark#readme",
   "dependencies": {
-    "remark": "^5.0.1",
-    "unified-engine": "^1.5.1"
+    "remark": "^6.0.0",
+    "unified-engine": "^2.0.0"
   },
   "devDependencies": {
-    "eslint": "^3.2.2",
+    "eslint": "^3.3.1",
     "eslint-config-google": "^0.6.0",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
-    "remark-cli": "^1.0.0",
-    "remark-lint": "^4.1.0"
+    "remark-cli": "^2.0.0",
+    "remark-lint": "^4.2.0"
   },
   "peerDependencies": {
     "grunt": ">= 0.4.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "remark-cli": "^2.0.0",
-    "remark-lint": "^4.2.0"
+    "remark-lint": "^5.0.0",
+    "remark-preset-lint-consistent": "^1.0.0",
+    "remark-preset-lint-recommended": "^1.0.0"
   },
   "peerDependencies": {
     "grunt": ">= 0.4.0"


### PR DESCRIPTION
This will require a [semver major bump](http://semver.org/) for this project.
And will need to wait until `remark-lint` which is what is used to test the code add support for `remark` 6.